### PR TITLE
Update to Tailwind 1.4.0 and implement native Tailwind PurgeCSS

### DIFF
--- a/assets/css/dev/postcss.config.js
+++ b/assets/css/dev/postcss.config.js
@@ -1,5 +1,8 @@
 module.exports = {    
-  plugins: [        
+  plugins: [       
+    require('postcss-import')({
+      path: ["assets/css"],
+    }),   
     require('tailwindcss')('./assets/css/tailwind.config.js'),    
     require('autoprefixer')({      
       overrideBrowserslist: ['>1%']

--- a/assets/css/dev/postcss.config.js
+++ b/assets/css/dev/postcss.config.js
@@ -1,14 +1,5 @@
-class TailwindExtractor {
-	static extract(content) {
-		return content.match(/[A-z0-9-:\/]+/g)
-	}
-}
-
 module.exports = {    
   plugins: [        
-    require('postcss-import')({
-      path: ["assets/css"],
-    }), 
     require('tailwindcss')('./assets/css/tailwind.config.js'),    
     require('autoprefixer')({      
       overrideBrowserslist: ['>1%']

--- a/assets/css/postcss.config.js
+++ b/assets/css/postcss.config.js
@@ -1,25 +1,8 @@
-class TailwindExtractor {
-	static extract(content) {
-		return content.match(/[A-z0-9-:\/]+/g)
-	}
-}
+
 
 module.exports = {    
   plugins: [        
-    require('postcss-import')({
-      path: ["assets/css"],
-    }), 
-    require('tailwindcss')('./assets/css/tailwind.config.js'),    
-    require('@fullhuman/postcss-purgecss')({
-      content: ['layouts/**/*.html'],
-      extractors: [
-      {
-        extractor: TailwindExtractor,
-        extensions: ['html']
-      }], 
-      fontFace: false,
-      whitelist: ['class1', 'class2']
-    }),    
+    require('tailwindcss')('./assets/css/tailwind.config.js'),       
     require('autoprefixer')({
       grid: true,
       overrideBrowserslist: ['>1%']

--- a/assets/css/postcss.config.js
+++ b/assets/css/postcss.config.js
@@ -1,7 +1,10 @@
 
 
 module.exports = {    
-  plugins: [        
+  plugins: [
+    require('postcss-import')({
+      path: ["assets/css"],
+    }),         
     require('tailwindcss')('./assets/css/tailwind.config.js'),       
     require('autoprefixer')({
       grid: true,

--- a/assets/css/tailwind.config.js
+++ b/assets/css/tailwind.config.js
@@ -1,7 +1,10 @@
 module.exports = {
-  purge: [
-    "./layouts/**/*.html"
-  ],
+  purge: {
+    content: ['./layouts/**/*.html'],
+    options: {
+      whitelist: [],
+    }
+},
   theme: {
     extend: {},
   },

--- a/assets/css/tailwind.config.js
+++ b/assets/css/tailwind.config.js
@@ -1,7 +1,8 @@
 module.exports = {
-  purge: [
-    './layouts/*.html',
-  ],
+  purge: {
+    enabled: true,
+    content: ['./layouts/**/*.html'],
+  },
   theme: {
     extend: {}
   },

--- a/assets/css/tailwind.config.js
+++ b/assets/css/tailwind.config.js
@@ -1,4 +1,7 @@
 module.exports = {
+  purge: [
+    './layouts/*.html',
+  ],
   theme: {
     extend: {}
   },

--- a/assets/css/tailwind.config.js
+++ b/assets/css/tailwind.config.js
@@ -1,11 +1,10 @@
 module.exports = {
-  purge: {
-    enabled: true,
-    content: ['./layouts/**/*.html'],
-  },
+  purge: [
+    "./layouts/**/*.html"
+  ],
   theme: {
-    extend: {}
+    extend: {},
   },
   variants: {},
-  plugins: []
-}
+  plugins: [],
+};

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "start": "hugo --gc"
   },
-  "devDependencies": {
+  "dependencies": {
     "@fullhuman/postcss-purgecss": "^1.3.0",
     "autoprefixer": "^9.7.3",
     "postcss": "^7.0.23",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,6 @@
     "postcss": "^7.0.23",
     "postcss-cli": "^6.1.3",
     "postcss-import": "^12.0.1",
-    "tailwindcss": "^1.1.4"
+    "tailwindcss": "^1.4.0"
   }
 }


### PR DESCRIPTION
With the release of Tailwind 1.4.0 the framework comes with native PurgeCSS funcionality. In an effort to make this boilerplate simpler and to reduce the amount of dependencies I think it is a good idea to implement it. 

I am opening this PR in order to work on this change. **As of now it is not working and I would appreciate help in where it could be improved.** 

Thanks!